### PR TITLE
Integración de LLaMA y nuevo endpoint IA

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,30 @@ Accede a [http://localhost:8000](http://localhost:8000) para comprobar que el se
 ```
 CAMILA Servidor Local Activo ✅
 ```
+
+5. **Descargar el modelo LLaMA-3.2-3b cuantizado**
+
+Descarga el modelo `gguf` de LLaMA y ubícalo en la carpeta `models/`. Define la
+variable de entorno `LLAMA_MODEL_PATH` con la ruta al archivo, por ejemplo:
+
+```bash
+export LLAMA_MODEL_PATH=./models/llama-3.2-3b-q4.gguf
+```
+
+6. **Probar el endpoint de IA**
+
+Con el servidor en marcha envía una petición POST a `/ia`:
+
+```bash
+curl -X POST http://localhost:8000/ia \
+     -H 'Content-Type: application/json' \
+     -d '{"pregunta": "¿Hola?"}'
+```
+
+La respuesta incluirá una clave `respuesta` generada por el modelo.
+
+7. **Ejecutar las pruebas automáticas**
+
+```bash
+pytest
+```

--- a/main.py
+++ b/main.py
@@ -1,12 +1,34 @@
+import os
 from starlette.applications import Starlette
-from starlette.responses import PlainTextResponse
+from starlette.responses import PlainTextResponse, JSONResponse
+from llama_cpp import Llama
 import uvicorn
 
 app = Starlette()
 
+llm = None
+
+@app.on_event("startup")
+async def load_model():
+    """Carga el modelo LLaMA al iniciar la aplicación."""
+    global llm
+    model_path = os.getenv("LLAMA_MODEL_PATH", "model.gguf")
+    llm = Llama(model_path=model_path)
+
 @app.route('/')
 async def read_root(request):
     return PlainTextResponse('CAMILA Servidor Local Activo ✅')
+
+
+@app.route('/ia', methods=['POST'])
+async def ia(request):
+    data = await request.json()
+    pregunta = data.get('pregunta')
+    if not pregunta:
+        return JSONResponse({'error': 'pregunta no proporcionada'}, status_code=400)
+    result = llm.create_completion(prompt=pregunta, max_tokens=128)
+    respuesta = result['choices'][0]['text'].strip()
+    return JSONResponse({'respuesta': respuesta})
 
 if __name__ == '__main__':
     uvicorn.run(app, host='0.0.0.0', port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 nginx
 starlette
 uvicorn
+llama-cpp-python
+pytest

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,15 @@
+import os
+import main
+from starlette.testclient import TestClient
+
+class DummyLlama:
+    def create_completion(self, prompt, max_tokens=128):
+        return {"choices": [{"text": "respuesta de prueba"}]}
+
+def test_ia_endpoint(monkeypatch):
+    monkeypatch.setattr(main, "Llama", lambda model_path: DummyLlama())
+    monkeypatch.setenv("LLAMA_MODEL_PATH", "dummy")
+    with TestClient(main.app) as client:
+        response = client.post("/ia", json={"pregunta": "Hola?"})
+        assert response.status_code == 200
+        assert response.json()["respuesta"] == "respuesta de prueba"


### PR DESCRIPTION
## Resumen
- integrar `llama-cpp-python` para usar LLaMA local
- exponer endpoint **/ia** que responde a preguntas
- documentar descarga y uso del modelo en README
- añadir dependencias requeridas
- agregar prueba automática del endpoint

## Testing
- `pytest -q` *(falla: comando no encontrado)*