### PR TITLE
Integrar memoria persistente

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,24 @@ curl -X POST http://localhost:8000/ia \
 
 La respuesta incluirá una clave `respuesta` generada por el modelo.
 
-7. **Ejecutar las pruebas automáticas**
+7. **Usar la memoria persistente**
+
+Para guardar información contextual envía una petición POST a `/memoria/guardar`:
+
+```bash
+curl -X POST http://localhost:8000/memoria/guardar \
+     -H 'Content-Type: application/json' \
+     -d '{"contenido": "mi texto"}'
+```
+
+Recupera todo lo almacenado con una petición GET a `/memoria/recuperar`:
+
+```bash
+curl http://localhost:8000/memoria/recuperar
+```
+
+La respuesta contendrá una lista `memoria` con los textos guardados.
+8. **Ejecutar las pruebas automáticas**
 
 ```bash
 pytest

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ from starlette.applications import Starlette
 from starlette.responses import PlainTextResponse, JSONResponse
 from llama_cpp import Llama
 import uvicorn
+from memoria import guardar_info, recuperar_info
 
 app = Starlette()
 
@@ -29,6 +30,23 @@ async def ia(request):
     result = llm.create_completion(prompt=pregunta, max_tokens=128)
     respuesta = result['choices'][0]['text'].strip()
     return JSONResponse({'respuesta': respuesta})
+
+
+@app.route('/memoria/guardar', methods=['POST'])
+async def memoria_guardar(request):
+    data = await request.json()
+    contenido = data.get('contenido')
+    if not contenido:
+        return JSONResponse({'error': 'contenido no proporcionado'}, status_code=400)
+    guardar_info(contenido)
+    return JSONResponse({'status': 'guardado'})
+
+
+@app.route('/memoria/recuperar', methods=['GET'])
+async def memoria_recuperar(request):
+    docs = recuperar_info()
+    textos = [doc.page_content for doc in docs]
+    return JSONResponse({'memoria': textos})
 
 if __name__ == '__main__':
     uvicorn.run(app, host='0.0.0.0', port=8000)

--- a/memoria.py
+++ b/memoria.py
@@ -1,0 +1,27 @@
+import uuid
+import chromadb
+from langchain.schema import Document
+
+_client = None
+_collection = None
+
+
+def init_memoria(persist_directory: str = "memoria_db"):
+    """Inicializa el cliente y la colección de ChromaDB."""
+    global _client, _collection
+    if _client is None:
+        _client = chromadb.PersistentClient(path=persist_directory)
+        _collection = _client.get_or_create_collection("memoria")
+
+
+def guardar_info(contenido: str) -> None:
+    """Guarda un texto en la base de memoria persistente."""
+    init_memoria()
+    _collection.add(documents=[contenido], ids=[str(uuid.uuid4())])
+
+
+def recuperar_info() -> list[Document]:
+    """Recupera todos los documentos almacenados."""
+    init_memoria()
+    result = _collection.get(include=["documents"])
+    return [Document(page_content=doc) for doc in result.get("documents", [])]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ starlette
 uvicorn
 llama-cpp-python
 pytest
+chromadb
+langchain

--- a/tests/test_memoria.py
+++ b/tests/test_memoria.py
@@ -1,0 +1,27 @@
+import types
+import memoria
+from memoria import guardar_info, recuperar_info
+
+class DummyCollection:
+    def __init__(self):
+        self.docs = []
+    def add(self, documents, ids):
+        self.docs.extend(documents)
+    def get(self, include=None):
+        return {"documents": self.docs}
+
+class DummyClient:
+    def __init__(self, path=None):
+        self.collection = DummyCollection()
+    def get_or_create_collection(self, name):
+        return self.collection
+
+def test_memoria(monkeypatch):
+    dummy_chroma = types.SimpleNamespace(PersistentClient=DummyClient)
+    monkeypatch.setattr(memoria, "chromadb", dummy_chroma)
+    memoria._client = None
+    memoria._collection = None
+
+    guardar_info("dato")
+    docs = recuperar_info()
+    assert docs[0].page_content == "dato"


### PR DESCRIPTION
## Summary
- integrate ChromaDB persistent memory via new module `memoria.py`
- expose `/memoria/guardar` and `/memoria/recuperar` endpoints
- document how to use persistent memory
- add `chromadb` and `langchain` to requirements
- test memory module with a dummy Chroma implementation

## Testing
- `git pull origin main` *(fails: repository not found)*
- `pytest -q` *(fails: command not found)*