### PR TITLE
Fix LLaMA model path and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,9 @@ CAMILA Servidor Local Activo ✅
 
 5. **Descargar el modelo LLaMA-3.2-3b cuantizado**
 
-Descarga el modelo `gguf` de LLaMA y ubícalo en la carpeta `models/`. Define la
-variable de entorno `LLAMA_MODEL_PATH` con la ruta al archivo, por ejemplo:
-
-```bash
-export LLAMA_MODEL_PATH=./models/llama-3.2-3b-q4.gguf
-```
+Descarga manualmente el archivo `llama-3-2-3b-q4.gguf` desde Hugging Face.
+Guárdalo en la carpeta `models` que se incluye en este proyecto. El servidor
+buscará el modelo en `models/llama-3-2-3b-q4.gguf` al iniciar.
 
 6. **Probar el endpoint de IA**
 

--- a/main.py
+++ b/main.py
@@ -13,8 +13,8 @@ llm = None
 async def load_model():
     """Carga el modelo LLaMA al iniciar la aplicación."""
     global llm
-    model_path = os.getenv("LLAMA_MODEL_PATH", "model.gguf")
-    llm = Llama(model_path=model_path)
+    # Ruta fija al modelo cuantizado LLaMA-3.2-3b
+    llm = Llama(model_path="models/llama-3-2-3b-q4.gguf")
 
 @app.route('/')
 async def read_root(request):


### PR DESCRIPTION
## Summary
- create `models` folder for local LLaMA files
- document how to manually download and place `llama-3-2-3b-q4.gguf`
- load model from `models/llama-3-2-3b-q4.gguf` in `main.py`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*