### PR TITLE
Add /status endpoint and test

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/src/main.py
+++ b/src/main.py
@@ -1,52 +1,66 @@
 import os
+from contextlib import asynccontextmanager
 from starlette.applications import Starlette
 from starlette.responses import PlainTextResponse, JSONResponse
+from starlette.routing import Route
 from llama_cpp import Llama
 import uvicorn
-from .memoria import guardar_info, recuperar_info
 
-app = Starlette()
+from .memoria import guardar_info, recuperar_info
 
 llm = None
 
-@app.on_event("startup")
-async def load_model():
-    """Carga el modelo LLaMA al iniciar la aplicación."""
+@asynccontextmanager
+async def lifespan(app: Starlette):
+    """Load the LLaMA model when the app starts."""
     global llm
-    # Ruta fija al modelo cuantizado LLaMA-3.2-3B Instruct
-    llm = Llama(model_path="models/Llama-3.2-3B-Instruct-Q4_K_M.gguf")
-
-@app.route('/')
-async def read_root(request):
-    return PlainTextResponse('CAMILA Servidor Local Activo ✅')
+    model_path = os.getenv("LLAMA_MODEL_PATH", "models/Llama-3.2-3B-Instruct-Q4_K_M.gguf")
+    llm = Llama(model_path=model_path)
+    yield
 
 
-@app.route('/ia', methods=['POST'])
+async def home(request):
+    return PlainTextResponse("CAMILA Servidor Local Activo ✅")
+
+
+async def status(request):
+    return JSONResponse({"status": "CAMILA operativo ✅"})
+
+
 async def ia(request):
     data = await request.json()
-    pregunta = data.get('pregunta')
+    pregunta = data.get("pregunta")
     if not pregunta:
-        return JSONResponse({'error': 'pregunta no proporcionada'}, status_code=400)
+        return JSONResponse({"error": "pregunta no proporcionada"}, status_code=400)
     result = llm.create_completion(prompt=pregunta, max_tokens=128)
-    respuesta = result['choices'][0]['text'].strip()
-    return JSONResponse({'respuesta': respuesta})
+    respuesta = result["choices"][0]["text"].strip()
+    return JSONResponse({"respuesta": respuesta})
 
 
-@app.route('/memoria/guardar', methods=['POST'])
 async def memoria_guardar(request):
     data = await request.json()
-    contenido = data.get('contenido')
+    contenido = data.get("contenido")
     if not contenido:
-        return JSONResponse({'error': 'contenido no proporcionado'}, status_code=400)
+        return JSONResponse({"error": "contenido no proporcionado"}, status_code=400)
     guardar_info(contenido)
-    return JSONResponse({'status': 'guardado'})
+    return JSONResponse({"status": "guardado"})
 
 
-@app.route('/memoria/recuperar', methods=['GET'])
 async def memoria_recuperar(request):
     docs = recuperar_info()
     textos = [doc.page_content for doc in docs]
-    return JSONResponse({'memoria': textos})
+    return JSONResponse({"memoria": textos})
 
-if __name__ == '__main__':
-    uvicorn.run(app, host='0.0.0.0', port=8000)
+
+routes = [
+    Route("/", home, methods=["GET"]),
+    Route("/status", status, methods=["GET"]),
+    Route("/ia", ia, methods=["POST"]),
+    Route("/memoria/guardar", memoria_guardar, methods=["POST"]),
+    Route("/memoria/recuperar", memoria_recuperar, methods=["GET"]),
+]
+
+app = Starlette(routes=routes, lifespan=lifespan)
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -13,3 +13,13 @@ def test_ia_endpoint(monkeypatch):
         response = client.post("/ia", json={"pregunta": "Hola?"})
         assert response.status_code == 200
         assert response.json()["respuesta"] == "respuesta de prueba"
+
+
+def test_status_endpoint():
+    from starlette.testclient import TestClient
+    from src.main import app
+
+    with TestClient(app) as client:
+        response = client.get("/status")
+        assert response.status_code == 200
+        assert response.json() == {"status": "CAMILA operativo ✅"}


### PR DESCRIPTION
## Summary
- add Starlette lifespan for model loading
- define routes using `Route`
- add `/status` endpoint
- test new endpoint alongside existing ones

## Testing
- `pytest -q` *(fails: command not found)*