### PR TITLE
Fix missing React imports

### DIFF
--- a/frontend/components/AskSection.js
+++ b/frontend/components/AskSection.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 export default function AskSection({ question, onQuestionChange, onSend, answer }) {
   return (
     <section>

--- a/frontend/components/Layout.js
+++ b/frontend/components/Layout.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 export default function Layout({ children }) {
   return (
     <main style={{ padding: '2rem' }}>

--- a/frontend/components/MemorySection.js
+++ b/frontend/components/MemorySection.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 export default function MemorySection({ memory, onMemoryChange, onSave, onRetrieve, data }) {
   return (
     <section>

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,8 +1,10 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { CopilotProvider } from '@copilotkit/react-core';
-import Layout from '../components/Layout';
-import AskSection from '../components/AskSection';
-import MemorySection from '../components/MemorySection';
+// Importamos los componentes de manera explícita con la extensión
+// para evitar resolver rutas incorrectas en ciertos entornos de build.
+import Layout from '../components/Layout.js';
+import AskSection from '../components/AskSection.js';
+import MemorySection from '../components/MemorySection.js';
 
 export default function Home() {
   const [question, setQuestion] = useState('');


### PR DESCRIPTION
## Summary
- merge main into work to sync
- explicitly reference component paths with `.js` extension

## Testing
- `npm test --silent --prefix frontend` *(fails: jest not found)*