### PR TITLE
Fix frontend version mismatch

### DIFF
--- a/frontend/components/AskSection.js
+++ b/frontend/components/AskSection.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 export default function AskSection({ question, onQuestionChange, onSend, answer }) {
   return (
     <section>

--- a/frontend/components/Layout.js
+++ b/frontend/components/Layout.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 export default function Layout({ children }) {
   return (
     <main style={{ padding: '2rem' }}>

--- a/frontend/components/MemorySection.js
+++ b/frontend/components/MemorySection.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 export default function MemorySection({ memory, onMemoryChange, onSave, onRetrieve, data }) {
   return (
     <section>

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: { appDir: false }
+};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,14 +8,14 @@
     "test": "jest"
   },
   "dependencies": {
-    "next": "latest",
-    "react": "latest",
-    "react-dom": "latest",
-    "@copilotkit/react-core": "latest"
+    "next": "13.5.6",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@copilotkit/react-core": "0.3.5"
   },
   "devDependencies": {
-    "jest": "latest",
-    "@testing-library/react": "latest",
-    "@testing-library/jest-dom": "latest"
+    "jest": "29.7.0",
+    "@testing-library/react": "14.1.2",
+    "@testing-library/jest-dom": "6.0.1"
   }
 }

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,8 +1,10 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { CopilotProvider } from '@copilotkit/react-core';
-import Layout from '../components/Layout';
-import AskSection from '../components/AskSection';
-import MemorySection from '../components/MemorySection';
+// Importamos los componentes de manera explícita con la extensión
+// para evitar resolver rutas incorrectas en ciertos entornos de build.
+import Layout from '../components/Layout.js';
+import AskSection from '../components/AskSection.js';
+import MemorySection from '../components/MemorySection.js';
 
 export default function Home() {
   const [question, setQuestion] = useState('');


### PR DESCRIPTION
## Summary
- pin Next.js, React and testing library versions
- add default `next.config.js` to disable app directory and enable strict mode

## Testing
- `npm test --silent --prefix frontend` *(fails: jest not found)*